### PR TITLE
Streamline widgets instantiation and patching

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -34,8 +34,8 @@
             ],
             "windowsSdkVersion": "10.0.22621.0",
             "compilerPath": "cl.exe",
-            "cStandard": "c17",
-            "cppStandard": "c++17",
+            "cStandard": "c23",
+            "cppStandard": "c++23",
             "intelliSenseMode": "windows-msvc-x64"
         }
     ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -114,7 +114,8 @@
         "strstream": "cpp",
         "valarray": "cpp",
         "*.inc": "cpp",
-        "__config": "cpp"
+        "__config": "cpp",
+        "semaphore": "cpp"
     },
     "prettier.prettierPath": "./packages/dear-imgui/ts/node_modules/prettier",
     "prettier.configPath": "./packages/dear-imgui/ts/.prettierrc.json",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -115,7 +115,9 @@
         "valarray": "cpp",
         "*.inc": "cpp",
         "__config": "cpp",
-        "semaphore": "cpp"
+        "semaphore": "cpp",
+        "*.tcc": "cpp",
+        "numbers": "cpp"
     },
     "prettier.prettierPath": "./packages/dear-imgui/ts/node_modules/prettier",
     "prettier.configPath": "./packages/dear-imgui/ts/.prettierrc.json",

--- a/packages/dear-imgui/cpp/reactimgui.cpp
+++ b/packages/dear-imgui/cpp/reactimgui.cpp
@@ -63,169 +63,65 @@ void ReactImgui::InitWidget(const json& widgetDef) {
     std::string type = widgetDef["type"].template get<std::string>();
     int id = widgetDef["id"].template get<int>();
 
+    m_widgets_mutex.lock();
+    m_hierarchy_mutex.lock();
+
+    if (type == "Combo") {
+        m_widgets[id] = Combo::makeWidget(widgetDef);
+    } else if (type == "Slider") {
+        m_widgets[id] = Slider::makeWidget(widgetDef);
+    } else if (type == "InputText") {
+        m_widgets[id] = InputText::makeWidget(widgetDef);
+    } else if (type == "MultiSlider") {
+        m_widgets[id] = MultiSlider::makeWidget(widgetDef);
+    } else if (type == "Checkbox") {
+        m_widgets[id] = Checkbox::makeWidget(widgetDef);
+    } else if (type == "Button") {
+        m_widgets[id] = Button::makeWidget(widgetDef);
+    } else if (type == "Fragment") {
+        m_widgets[id] = std::make_unique<Fragment>(id);
+    } else if (type == "SameLine") {
+        m_widgets[id] = std::make_unique<SameLine>(id);
+    } else if (type == "Separator") {
+        m_widgets[id] = std::make_unique<Separator>(id);
+    } else if (type == "Indent") {
+        m_widgets[id] = std::make_unique<Indent>(id);
+    } else if (type == "Unindent") {
+        m_widgets[id] = std::make_unique<Indent>(id);
+    } else if (type == "SeparatorText") {
+        std::string label = widgetDef["label"].template get<std::string>();
+        m_widgets[id] = std::make_unique<SeparatorText>(id, label);
+    } else if (type == "BulletText") {
+        std::string text = widgetDef["text"].template get<std::string>();
+        m_widgets[id] = std::make_unique<BulletText>(id, text);
+    } else if (type == "UnformattedText") {
+        std::string text = widgetDef["text"].template get<std::string>();
+        m_widgets[id] = std::make_unique<UnformattedText>(id, text);
+    } else if (type == "DisabledText") {
+        std::string text = widgetDef["text"].template get<std::string>();
+        m_widgets[id] = std::make_unique<DisabledText>(id, text);
+    } else if (type == "TabBar") {
+        m_widgets[id] = std::make_unique<TabBar>(id);
+    } else if (type == "TabItem") {
+        std::string label = widgetDef["label"].template get<std::string>();
+        m_widgets[id] = std::make_unique<TabItem>(id, label);
+    } else if (type == "CollapsingHeader") {
+        std::string label = widgetDef["label"].template get<std::string>();
+        m_widgets[id] = std::make_unique<CollapsingHeader>(id, label);
+    } else if (type == "TextWrap") {
+        double width = widgetDef["width"].template get<double>();
+        m_widgets[id] = std::make_unique<TextWrap>(id, width);
+    } else if (type == "ItemTooltip") {
+        m_widgets[id] = std::make_unique<ItemTooltip>(id);
+    } else if (type == "TreeNode") {
+        std::string label = widgetDef["label"].template get<std::string>();
+        m_widgets[id] = std::make_unique<TreeNode>(id, label);
+    }
+
     m_hierarchy[id] = std::vector<int>();
 
-    if (type == "InputText") {
-        InitInputText(widgetDef);
-    } else if (type == "Combo") {
-        InitBasicCombo(widgetDef);
-    } else if (type == "Slider") {
-        InitSlider(widgetDef);
-    } else if (type == "MultiSlider") {
-        InitMultiSlider(widgetDef);
-    } else if (type == "Checkbox") {
-        InitCheckbox(widgetDef);
-    } else if (type == "Button") {
-        InitButton(widgetDef);
-    } else { 
-        m_widgets_mutex.lock();
-
-        if (type == "Fragment") {
-            m_widgets[id] = std::make_unique<Fragment>(id);
-        } else if (type == "SameLine") {
-            m_widgets[id] = std::make_unique<SameLine>(id);
-        } else if (type == "Separator") {
-            m_widgets[id] = std::make_unique<Separator>(id);
-        } else if (type == "Indent") {
-            m_widgets[id] = std::make_unique<Indent>(id);
-        } else if (type == "Unindent") {
-            m_widgets[id] = std::make_unique<Indent>(id);
-        } else if (type == "SeparatorText") {
-            std::string label = widgetDef["label"].template get<std::string>();
-            m_widgets[id] = std::make_unique<SeparatorText>(id, label);
-        } else if (type == "BulletText") {
-            std::string text = widgetDef["text"].template get<std::string>();
-            m_widgets[id] = std::make_unique<BulletText>(id, text);
-        } else if (type == "UnformattedText") {
-            std::string text = widgetDef["text"].template get<std::string>();
-            m_widgets[id] = std::make_unique<UnformattedText>(id, text);
-        } else if (type == "DisabledText") {
-            std::string text = widgetDef["text"].template get<std::string>();
-            m_widgets[id] = std::make_unique<DisabledText>(id, text);
-        } else if (type == "TabBar") {
-            m_widgets[id] = std::make_unique<TabBar>(id);
-        } else if (type == "TabItem") {
-            std::string label = widgetDef["label"].template get<std::string>();
-            m_widgets[id] = std::make_unique<TabItem>(id, label);
-        } else if (type == "CollapsingHeader") {
-            std::string label = widgetDef["label"].template get<std::string>();
-            m_widgets[id] = std::make_unique<CollapsingHeader>(id, label);
-        } else if (type == "TextWrap") {
-            double width = widgetDef["width"].template get<double>();
-            m_widgets[id] = std::make_unique<TextWrap>(id, width);
-        } else if (type == "ItemTooltip") {
-            m_widgets[id] = std::make_unique<ItemTooltip>(id);
-        } else if (type == "TreeNode") {
-            std::string label = widgetDef["label"].template get<std::string>();
-            m_widgets[id] = std::make_unique<TreeNode>(id, label);
-        }
-
-        m_widgets_mutex.unlock();
-    }
-};
-
-void ReactImgui::InitButton(const json& val) {
-    if (!val.contains("id") || !val["id"].is_number_integer()) {
-        // throw?
-    }
-
-    auto id = val["id"].template get<int>();
-    auto label = val.contains("label") && val["label"].is_string() ? val["label"].template get<std::string>() : "";
-
-    m_widgets_mutex.lock();
-    if (m_widgets.contains(id)) {
-        auto pButton = static_cast<Button*>(m_widgets[id].get());
-
-        pButton->m_label = label;
-    } else {
-        m_widgets[id] = Button::makeButtonWidget(id, label);
-    }
     m_widgets_mutex.unlock();
-};
-
-void ReactImgui::InitCheckbox(const json& val) {
-    if (!val.contains("id") || !val["id"].is_number_integer()) {
-        // throw?
-    }
-
-    auto id = val["id"].template get<int>();
-    auto defaultChecked = val.contains("defaultChecked") && val["defaultChecked"].is_boolean() ? val["defaultChecked"].template get<bool>() : false;
-    auto label = val.contains("label") && val["label"].is_string() ? val["label"].template get<std::string>() : "";
-
-    m_widgets_mutex.lock();
-    if (m_widgets.contains(id)) {
-        auto pCheckbox = static_cast<Checkbox*>(m_widgets[id].get());
-
-        pCheckbox->m_label = label;
-    } else {
-        m_widgets[id] = Checkbox::makeCheckboxWidget(id, label, defaultChecked);
-    }
-    m_widgets_mutex.unlock();
-};
-
-void ReactImgui::InitSlider(const json& val) {
-    if (!val.contains("id") || !val["id"].is_number_integer()) {
-        // throw?
-    }
-
-    auto id = val["id"].template get<int>();
-    auto defaultValue = val.contains("defaultValue") && val["defaultValue"].is_number() ? val["defaultValue"].template get<float>() : 0.0f;
-    auto min = val.contains("min") && val["min"].is_number() ? val["min"].template get<float>() : 0.0f;
-    auto max = val.contains("max") && val["max"].is_number() ? val["max"].template get<float>() : 10.0f;
-    auto label = val.contains("label") && val["label"].is_string() ? val["label"].template get<std::string>() : "";
-    auto sliderType = val.contains("sliderType") && val["sliderType"].is_string() ? val["sliderType"].template get<std::string>() : "default";
-
-    m_widgets_mutex.lock();
-    if (m_widgets.contains(id)) {
-        auto pSlider = static_cast<Slider*>(m_widgets[id].get());
-
-        pSlider->m_label = label;
-        
-        if (pSlider->m_value > max) {
-            // Don't want to go out of bounds!
-            pSlider->m_value = max;
-        }
-
-        pSlider->m_min = min;
-        pSlider->m_max = max;
-    } else {
-        m_widgets[id] = Slider::makeSliderWidget(id, label, defaultValue, min, max, sliderType);
-    }
-    m_widgets_mutex.unlock();
-};
-
-void ReactImgui::InitMultiSlider(const json& val) {
-    if (!val.contains("id") || !val["id"].is_number_integer()) {
-        // throw?
-    }
-
-    auto id = val["id"].template get<int>();
-    auto numValues = val.contains("numValues") && val["numValues"].is_number() ? val["numValues"].template get<int>() : 2;
-    auto decimalDigits = val.contains("decimalDigits") && val["decimalDigits"].is_number() ? val["decimalDigits"].template get<int>() : 0;
-    
-    auto min = val.contains("min") && val["min"].is_number() ? val["min"].template get<float>() : 0.0f;
-    auto max = val.contains("max") && val["max"].is_number() ? val["max"].template get<float>() : 10.0f;
-    auto label = val.contains("label") && val["label"].is_string() ? val["label"].template get<std::string>() : "";
-
-    m_widgets_mutex.lock();
-    if (m_widgets.contains(id)) {
-        auto pMultiSlider = static_cast<MultiSlider*>(m_widgets[id].get());
-
-        pMultiSlider->m_label = label;
-        
-        // todo: Changing numValues should probably throw - or emit a warning?
-
-        pMultiSlider->m_min = min;
-        pMultiSlider->m_max = max;
-        pMultiSlider->m_decimalDigits = decimalDigits;
-    } else {
-        if (val.contains("defaultValues") && val["defaultValues"].is_array() && val["defaultValues"].size() == numValues) {
-            m_widgets[id] = MultiSlider::makeMultiSliderWidget(id, label, min, max, numValues, decimalDigits, val["defaultValues"]);
-        } else {
-            m_widgets[id] = MultiSlider::makeMultiSliderWidget(id, label, min, max, numValues, decimalDigits);
-        }
-    }
-    m_widgets_mutex.unlock();
+    m_hierarchy_mutex.unlock();
 };
 
 void ReactImgui::SetEventHandlers(
@@ -244,46 +140,6 @@ void ReactImgui::SetEventHandlers(
     m_onClick = onClickFn;
 
     Widget::onInputTextChange_ = onInputTextChangeFn;
-};
-
-void ReactImgui::InitInputText(const json& val) {
-    if (!val.contains("id") || !val["id"].is_number_integer()) {
-        // throw?
-    }
-
-    auto id = val["id"].template get<int>();
-    auto defaultValue = val.contains("defaultValue") && val["defaultValue"].is_string() ? val["defaultValue"].template get<std::string>() : "";
-    auto label = val.contains("label") && val["label"].is_string() ? val["label"].template get<std::string>() : "";
-
-    m_widgets_mutex.lock();
-    if (m_widgets.contains(id)) {
-        auto pInputText = static_cast<InputText*>(m_widgets[id].get());
-
-        pInputText->m_label = label;
-    } else {
-        m_widgets[id] = InputText::makeInputTextWidget(id, defaultValue, label);
-    }
-    m_widgets_mutex.unlock();
-};
-
-void ReactImgui::InitBasicCombo(const json& val) {
-    if (!val.contains("id") || !val["id"].is_number_integer()) {
-        // throw?
-    }
-
-    auto id = val["id"].template get<int>();
-    auto defaultValue = val.contains("defaultValue") && val["defaultValue"].is_number() ? val["defaultValue"].template get<int>() : 0;
-    auto label = val["label"].template get<std::string>();
-    
-    m_widgets_mutex.lock();
-    if (m_widgets.contains(id)) {
-        auto pCombo = static_cast<Combo*>(m_widgets[id].get());
-
-        pCombo->m_label = label;
-    } else {
-        m_widgets[id] = Combo::makeComboWidget(id, label, defaultValue, val["optionsList"].template get<std::string>());
-    }
-    m_widgets_mutex.unlock();
 };
 
 void ReactImgui::SetUpFloatFormatChars() {
@@ -369,88 +225,16 @@ void ReactImgui::SetWidget(std::string widgetJsonAsString) {
 };
 
 void ReactImgui::PatchWidget(int id, std::string widgetJsonAsString) {
+    m_widgets_mutex.lock();
+
     if (m_widgets.contains(id)) {
         auto widgetDef = json::parse(widgetJsonAsString);
-
-        m_widgets_mutex.lock();
-
         auto pWidget = m_widgets[id].get();
-        auto type = pWidget->m_type;
 
-        if (type == "InputText") {
-            if (widgetDef.contains("label") && widgetDef["label"].is_string()) {
-                static_cast<InputText*>(pWidget)->m_label = widgetDef["label"].template get<std::string>();
-            }
-        } else if (type == "Combo") {
-            if (widgetDef.contains("label") && widgetDef["label"].is_string()) {
-                static_cast<Combo*>(pWidget)->m_label = widgetDef["label"].template get<std::string>();
-            }
-        } else if (type == "Slider") {
-            if (widgetDef.contains("label") && widgetDef["label"].is_string()) {
-                static_cast<Slider*>(pWidget)->m_label = widgetDef["label"].template get<std::string>();
-            }
-        } else if (type == "MultiSlider") {
-            if (widgetDef.contains("label") && widgetDef["label"].is_string()) {
-                static_cast<MultiSlider*>(pWidget)->m_label = widgetDef["label"].template get<std::string>();
-            }
-        } else if (type == "Checkbox") {
-            if (widgetDef.contains("label") && widgetDef["label"].is_string()) {
-                static_cast<Checkbox*>(pWidget)->m_label = widgetDef["label"].template get<std::string>();
-            }
-        } else if (type == "Button") {
-            if (widgetDef.contains("label") && widgetDef["label"].is_string()) {
-                static_cast<Button*>(pWidget)->m_label = widgetDef["label"].template get<std::string>();
-            }
-        } else if (type == "Fragment") {
-            
-        } else if (type == "SameLine") {
-            
-        } else if (type == "Separator") {
-            
-        } else if (type == "Indent") {
-            
-        } else if (type == "Unindent") {
-            
-        } else if (type == "SeparatorText") {
-            if (widgetDef.contains("label") && widgetDef["label"].is_string()) {
-                static_cast<SeparatorText*>(pWidget)->m_label = widgetDef["label"].template get<std::string>();
-            }
-        } else if (type == "BulletText") {
-            if (widgetDef.contains("text") && widgetDef["text"].is_string()) {
-                static_cast<BulletText*>(pWidget)->m_text = widgetDef["text"].template get<std::string>();
-            }
-        } else if (type == "UnformattedText") {
-            if (widgetDef.contains("text") && widgetDef["text"].is_string()) {
-                static_cast<UnformattedText*>(pWidget)->m_text = widgetDef["text"].template get<std::string>();
-            }
-        } else if (type == "DisabledText") {
-            if (widgetDef.contains("text") && widgetDef["text"].is_string()) {
-                static_cast<DisabledText*>(pWidget)->m_text = widgetDef["text"].template get<std::string>();
-            }
-        } else if (type == "TabBar") {
-            
-        } else if (type == "TabItem") {
-            if (widgetDef.contains("label") && widgetDef["label"].is_string()) {
-                static_cast<TabItem*>(pWidget)->m_label = widgetDef["label"].template get<std::string>();
-            }
-        } else if (type == "CollapsingHeader") {
-            if (widgetDef.contains("label") && widgetDef["label"].is_string()) {
-                static_cast<CollapsingHeader*>(pWidget)->m_label = widgetDef["label"].template get<std::string>();
-            }
-        } else if (type == "TextWrap") {
-            if (widgetDef.contains("width") && widgetDef["width"].is_number()) {
-                static_cast<TextWrap*>(pWidget)->m_width = widgetDef["width"].template get<double>();
-            }
-        } else if (type == "ItemTooltip") {
-            
-        } else if (type == "TreeNode") {
-            if (widgetDef.contains("label") && widgetDef["label"].is_string()) {
-                static_cast<TreeNode*>(pWidget)->m_label = widgetDef["label"].template get<std::string>();
-            }
-        }
-
-        m_widgets_mutex.unlock();
+        pWidget->Patch(widgetDef);
     }
+
+    m_widgets_mutex.unlock();
 };
 
 void ReactImgui::SetChildren(int id, std::vector<int> childrenIds) {

--- a/packages/dear-imgui/cpp/reactimgui.cpp
+++ b/packages/dear-imgui/cpp/reactimgui.cpp
@@ -79,15 +79,15 @@ void ReactImgui::InitWidget(const json& widgetDef) {
     } else if (type == "Button") {
         m_widgets[id] = Button::makeWidget(widgetDef);
     } else if (type == "Fragment") {
-        m_widgets[id] = std::make_unique<Fragment>(id);
+        m_widgets[id] = Widget::makeWidget<Fragment>(widgetDef);
     } else if (type == "SameLine") {
-        m_widgets[id] = std::make_unique<SameLine>(id);
+        m_widgets[id] = Widget::makeWidget<SameLine>(widgetDef);
     } else if (type == "Separator") {
-        m_widgets[id] = std::make_unique<Separator>(id);
+        m_widgets[id] = Widget::makeWidget<Separator>(widgetDef);
     } else if (type == "Indent") {
-        m_widgets[id] = std::make_unique<Indent>(id);
+        m_widgets[id] = Widget::makeWidget<Indent>(widgetDef);
     } else if (type == "Unindent") {
-        m_widgets[id] = std::make_unique<Indent>(id);
+        m_widgets[id] = Widget::makeWidget<Unindent>(widgetDef);
     } else if (type == "SeparatorText") {
         std::string label = widgetDef["label"].template get<std::string>();
         m_widgets[id] = std::make_unique<SeparatorText>(id, label);
@@ -101,7 +101,7 @@ void ReactImgui::InitWidget(const json& widgetDef) {
         std::string text = widgetDef["text"].template get<std::string>();
         m_widgets[id] = std::make_unique<DisabledText>(id, text);
     } else if (type == "TabBar") {
-        m_widgets[id] = std::make_unique<TabBar>(id);
+        m_widgets[id] = Widget::makeWidget<TabBar>(widgetDef);
     } else if (type == "TabItem") {
         std::string label = widgetDef["label"].template get<std::string>();
         m_widgets[id] = std::make_unique<TabItem>(id, label);
@@ -112,7 +112,7 @@ void ReactImgui::InitWidget(const json& widgetDef) {
         double width = widgetDef["width"].template get<double>();
         m_widgets[id] = std::make_unique<TextWrap>(id, width);
     } else if (type == "ItemTooltip") {
-        m_widgets[id] = std::make_unique<ItemTooltip>(id);
+        m_widgets[id] = Widget::makeWidget<ItemTooltip>(widgetDef);
     } else if (type == "TreeNode") {
         std::string label = widgetDef["label"].template get<std::string>();
         m_widgets[id] = std::make_unique<TreeNode>(id, label);

--- a/packages/dear-imgui/cpp/reactimgui.cpp
+++ b/packages/dear-imgui/cpp/reactimgui.cpp
@@ -89,33 +89,25 @@ void ReactImgui::InitWidget(const json& widgetDef) {
     } else if (type == "Unindent") {
         m_widgets[id] = Widget::makeWidget<Unindent>(widgetDef);
     } else if (type == "SeparatorText") {
-        std::string label = widgetDef["label"].template get<std::string>();
-        m_widgets[id] = std::make_unique<SeparatorText>(id, label);
+        m_widgets[id] = SeparatorText::makeWidget(widgetDef);
     } else if (type == "BulletText") {
-        std::string text = widgetDef["text"].template get<std::string>();
-        m_widgets[id] = std::make_unique<BulletText>(id, text);
+        m_widgets[id] = BulletText::makeWidget(widgetDef);
     } else if (type == "UnformattedText") {
-        std::string text = widgetDef["text"].template get<std::string>();
-        m_widgets[id] = std::make_unique<UnformattedText>(id, text);
+        m_widgets[id] = UnformattedText::makeWidget(widgetDef);
     } else if (type == "DisabledText") {
-        std::string text = widgetDef["text"].template get<std::string>();
-        m_widgets[id] = std::make_unique<DisabledText>(id, text);
+        m_widgets[id] = DisabledText::makeWidget(widgetDef);
     } else if (type == "TabBar") {
         m_widgets[id] = Widget::makeWidget<TabBar>(widgetDef);
     } else if (type == "TabItem") {
-        std::string label = widgetDef["label"].template get<std::string>();
-        m_widgets[id] = std::make_unique<TabItem>(id, label);
+        m_widgets[id] = TabItem::makeWidget(widgetDef);
     } else if (type == "CollapsingHeader") {
-        std::string label = widgetDef["label"].template get<std::string>();
-        m_widgets[id] = std::make_unique<CollapsingHeader>(id, label);
+        m_widgets[id] = CollapsingHeader::makeWidget(widgetDef);
     } else if (type == "TextWrap") {
-        double width = widgetDef["width"].template get<double>();
-        m_widgets[id] = std::make_unique<TextWrap>(id, width);
+        m_widgets[id] = TextWrap::makeWidget(widgetDef);
     } else if (type == "ItemTooltip") {
         m_widgets[id] = Widget::makeWidget<ItemTooltip>(widgetDef);
     } else if (type == "TreeNode") {
-        std::string label = widgetDef["label"].template get<std::string>();
-        m_widgets[id] = std::make_unique<TreeNode>(id, label);
+        m_widgets[id] = TreeNode::makeWidget(widgetDef);
     }
 
     m_hierarchy[id] = std::vector<int>();

--- a/packages/dear-imgui/cpp/reactimgui.h
+++ b/packages/dear-imgui/cpp/reactimgui.h
@@ -35,8 +35,6 @@ class ReactImgui : public ImPlotView {
         std::mutex m_widgets_mutex;
 
         void InitWidget(const json& widgetDef);
-        void InitButton(const json& val);
-        void InitCheckbox(const json& val);
         void InitSlider(const json& val);
         void InitMultiSlider(const json& val);
         void InitInputText(const json& val);

--- a/packages/dear-imgui/cpp/widget.h
+++ b/packages/dear-imgui/cpp/widget.h
@@ -35,7 +35,7 @@ class Widget {
 
         inline static OnTextChangedCallback onInputTextChange_;
 
-        template <typename T> 
+        template <class T> 
         static std::unique_ptr<T> makeWidget(const json& val) {
             if (val.is_object()) {
                 auto id = val["id"].template get<int>();

--- a/packages/dear-imgui/cpp/widget.h
+++ b/packages/dear-imgui/cpp/widget.h
@@ -44,6 +44,8 @@ class Widget {
         void HandleChildren(ReactImgui* view);
 
         virtual void Render(ReactImgui* view) = 0;
+
+        virtual void Patch(const json& val) = 0;
 };
 
 class Fragment final : public Widget {
@@ -56,6 +58,8 @@ class Fragment final : public Widget {
         }
 
         void Render(ReactImgui* view);
+
+        void Patch(const json& val) {}
 };
 
 class SameLine final : public Widget {
@@ -66,6 +70,8 @@ class SameLine final : public Widget {
         }
 
         void Render(ReactImgui* view);
+
+        void Patch(const json& val) {}
 };
 
 class Separator final : public Widget {
@@ -73,6 +79,8 @@ class Separator final : public Widget {
         Separator(int id) : Widget(id) {}
 
         void Render(ReactImgui* view);
+
+        void Patch(const json& val) {}
 };
 
 class Indent final : public Widget {
@@ -83,6 +91,8 @@ class Indent final : public Widget {
         }
 
         void Render(ReactImgui* view);
+
+        void Patch(const json& val) {}
 };
 
 // Likely unused
@@ -93,6 +103,8 @@ class Unindent final : public Widget {
         }
 
         void Render(ReactImgui* view);
+
+        void Patch(const json& val) {}
 };
 
 class SeparatorText final : public Widget {
@@ -105,6 +117,14 @@ class SeparatorText final : public Widget {
         }
 
         void Render(ReactImgui* view);
+
+        void Patch(const json& val) {
+            if (val.is_object()) {
+                if (val.contains("label") && val["label"].is_string()) {
+                    m_label = val["label"].template get<std::string>();
+                }
+            }
+        }
 };
 
 class BulletText final : public Widget {
@@ -117,6 +137,14 @@ class BulletText final : public Widget {
         }
 
         void Render(ReactImgui* view);
+
+        void Patch(const json& val) {
+            if (val.is_object()) {
+                if (val.contains("text") && val["text"].is_string()) {
+                    m_text = val["text"].template get<std::string>();
+                }
+            }
+        }
 };
 
 class UnformattedText final : public Widget {
@@ -129,6 +157,14 @@ class UnformattedText final : public Widget {
         }
 
         void Render(ReactImgui* view);
+
+        void Patch(const json& val) {
+            if (val.is_object()) {
+                if (val.contains("text") && val["text"].is_string()) {
+                    m_text = val["text"].template get<std::string>();
+                }
+            }
+        }
 };
 
 class DisabledText final : public Widget {
@@ -141,6 +177,14 @@ class DisabledText final : public Widget {
         }
 
         void Render(ReactImgui* view);
+
+        void Patch(const json& val) {
+            if (val.is_object()) {
+                if (val.contains("text") && val["text"].is_string()) {
+                    m_text = val["text"].template get<std::string>();
+                }
+            }
+        }
 };
 
 class TabBar final : public Widget {
@@ -151,6 +195,8 @@ class TabBar final : public Widget {
         }
 
         void Render(ReactImgui* view);
+
+        void Patch(const json& val) {}
 };
 
 class TabItem final : public Widget {
@@ -164,6 +210,14 @@ class TabItem final : public Widget {
         }
 
         void Render(ReactImgui* view);
+
+        void Patch(const json& val) {
+            if (val.is_object()) {
+                if (val.contains("label") && val["label"].is_string()) {
+                    m_label = val["label"].template get<std::string>();
+                }
+            }
+        }
 };
 
 class CollapsingHeader final : public Widget {
@@ -177,6 +231,14 @@ class CollapsingHeader final : public Widget {
         }
 
         void Render(ReactImgui* view);
+
+        void Patch(const json& val) {
+            if (val.is_object()) {
+                if (val.contains("label") && val["label"].is_string()) {
+                    m_label = val["label"].template get<std::string>();
+                }
+            }
+        }
 };
 
 class TextWrap final : public Widget {
@@ -190,6 +252,14 @@ class TextWrap final : public Widget {
         }
 
         void Render(ReactImgui* view);
+
+        void Patch(const json& val) {
+            if (val.is_object()) {
+                if (val.contains("width") && val["width"].is_string()) {
+                    m_width = val["width"].template get<double>();
+                }
+            }
+        }
 };
 
 class ItemTooltip final : public Widget {
@@ -200,6 +270,8 @@ class ItemTooltip final : public Widget {
         }
 
         void Render(ReactImgui* view);
+
+        void Patch(const json& val) {}
 };
 
 class TreeNode final : public Widget {
@@ -213,6 +285,14 @@ class TreeNode final : public Widget {
         }
 
         void Render(ReactImgui* view);
+
+        void Patch(const json& val) {
+            if (val.is_object()) {
+                if (val.contains("label") && val["label"].is_string()) {
+                    m_label = val["label"].template get<std::string>();
+                }
+            }
+        }
 };
 
 class Combo final : public Widget {
@@ -300,17 +380,38 @@ class Combo final : public Widget {
         std::string m_label;
         std::unique_ptr<char[]> m_itemsSeparatedByZeros; // Relevant for 'basic' combo only
 
-        static std::unique_ptr<Combo> makeComboWidget(int id, std::string label, int defaultValue, const json& options) {
+        static std::unique_ptr<Combo> makeWidget(const json& val) {
+            if (val.is_object()) {
+                auto id = val["id"].template get<int>();
+                auto defaultValue = val.contains("defaultValue") && val["defaultValue"].is_number() ? val["defaultValue"].template get<int>() : 0;
+                auto label = val["label"].template get<std::string>();
+                auto optionsList = val["optionsList"].template get<std::string>();
+
+                return Combo::makeWidget(id, label, defaultValue, optionsList);
+            }
+
+            throw std::invalid_argument("Invalid JSON data");
+        }
+
+        static std::unique_ptr<Combo> makeWidget(int id, std::string label, int defaultValue, const json& options) {
             Combo instance(id, label, defaultValue, options);
             return std::make_unique<Combo>(std::move(instance));
         }
 
-        static std::unique_ptr<Combo> makeComboWidget(int id, std::string label, int defaultValue, std::string optionsList) {
+        static std::unique_ptr<Combo> makeWidget(int id, std::string label, int defaultValue, std::string optionsList) {
             Combo instance(id, label, defaultValue, optionsList);
             return std::make_unique<Combo>(std::move(instance));
         }
 
         void Render(ReactImgui* view);
+
+        void Patch(const json& val) {
+            if (val.is_object()) {
+                if (val.contains("label") && val["label"].is_string()) {
+                    m_label = val["label"].template get<std::string>();
+                }
+            }
+        }
 };
 
 class InputText final : public Widget {
@@ -333,12 +434,33 @@ class InputText final : public Widget {
         std::string m_defaultValue;
         std::string m_label;
 
-        inline static std::unique_ptr<InputText> makeInputTextWidget(int id, std::string defaultValue, std::string label) {
+        inline static std::unique_ptr<InputText> makeWidget(const json& val) {
+            if (val.is_object()) {
+                auto id = val["id"].template get<int>();
+                auto defaultValue = val.contains("defaultValue") && val["defaultValue"].is_string() ? val["defaultValue"].template get<std::string>() : "";
+                auto label = val.contains("label") && val["label"].is_string() ? val["label"].template get<std::string>() : "";
+
+                return InputText::makeWidget(id, defaultValue, label);
+            }
+
+            throw std::invalid_argument("Invalid JSON data");
+        }
+
+        inline static std::unique_ptr<InputText> makeWidget(int id, std::string defaultValue, std::string label) {
             InputText instance(id, defaultValue, label);
             return std::make_unique<InputText>(std::move(instance));
         }
 
         void Render(ReactImgui* view);
+
+        void Patch(const json& val) {
+            if (val.is_object()) {
+                if (val.contains("label") && val["label"].is_string()) {
+                    m_label = val["label"].template get<std::string>();
+                }
+            }
+        }
+        
 };
 
 class Checkbox final : public Widget {
@@ -353,12 +475,32 @@ class Checkbox final : public Widget {
         bool m_checked;
         std::string m_label;
 
-        inline static std::unique_ptr<Checkbox> makeCheckboxWidget(int id, std::string label, bool defaultChecked) {
+        inline static std::unique_ptr<Checkbox> makeWidget(const json& val) {
+            if (val.is_object()) {
+                auto id = val["id"].template get<int>();
+                auto defaultChecked = val.contains("defaultChecked") && val["defaultChecked"].is_boolean() ? val["defaultChecked"].template get<bool>() : false;
+                auto label = val.contains("label") && val["label"].is_string() ? val["label"].template get<std::string>() : "";
+
+                return Checkbox::makeWidget(id, label, defaultChecked);
+            }
+
+            throw std::invalid_argument("Invalid JSON data");
+        }
+
+        inline static std::unique_ptr<Checkbox> makeWidget(int id, std::string label, bool defaultChecked) {
             Checkbox instance(id, label, defaultChecked);
             return std::make_unique<Checkbox>(std::move(instance));
         }
 
         void Render(ReactImgui* view);
+
+        void Patch(const json& val) {
+            if (val.is_object()) {
+                if (val.contains("label") && val["label"].is_string()) {
+                    m_label = val["label"].template get<std::string>();
+                }
+            }
+        }
 };
 
 class Button final : public Widget {
@@ -371,12 +513,31 @@ class Button final : public Widget {
     public:
         std::string m_label;
 
-        inline static std::unique_ptr<Button> makeButtonWidget(int id, std::string label) {
+        inline static std::unique_ptr<Button> makeWidget(const json& val) {
+            if (val.is_object()) {
+                auto id = val["id"].template get<int>();
+                auto label = val.contains("label") && val["label"].is_string() ? val["label"].template get<std::string>() : "";
+                
+                return Button::makeWidget(id, label);
+            }
+
+            throw std::invalid_argument("Invalid JSON data");
+        }
+
+        inline static std::unique_ptr<Button> makeWidget(int id, std::string label) {
             Button instance(id, label);
             return std::make_unique<Button>(std::move(instance));
         }
 
         void Render(ReactImgui* view);
+
+        void Patch(const json& val) {
+            if (val.is_object()) {
+                if (val.contains("label") && val["label"].is_string()) {
+                    m_label = val["label"].template get<std::string>();
+                }
+            }
+        }
 };
 
 class Slider final : public Widget {
@@ -397,12 +558,41 @@ class Slider final : public Widget {
         float m_max;
         std::string m_label;
 
-        inline static std::unique_ptr<Slider> makeSliderWidget(int id, std::string label, float defaultValue, float min, float max, std::string sliderType) {
+        inline static std::unique_ptr<Slider> makeWidget(const json& val) {
+            if (val.is_object()) {
+                auto id = val["id"].template get<int>();
+                auto defaultValue = val.contains("defaultValue") && val["defaultValue"].is_number() ? val["defaultValue"].template get<float>() : 0.0f;
+                auto min = val.contains("min") && val["min"].is_number() ? val["min"].template get<float>() : 0.0f;
+                auto max = val.contains("max") && val["max"].is_number() ? val["max"].template get<float>() : 10.0f;
+                auto label = val.contains("label") && val["label"].is_string() ? val["label"].template get<std::string>() : "";
+                auto sliderType = val.contains("sliderType") && val["sliderType"].is_string() ? val["sliderType"].template get<std::string>() : "default";
+
+                return Slider::makeWidget(id, label, defaultValue, min, max, sliderType);
+            }
+
+            throw std::invalid_argument("Invalid JSON data");
+        }
+
+        inline static std::unique_ptr<Slider> makeWidget(int id, std::string label, float defaultValue, float min, float max, std::string sliderType) {
             Slider instance(id, label, defaultValue, min, max, sliderType);
             return std::make_unique<Slider>(std::move(instance));
         }
 
         void Render(ReactImgui* view);
+
+        void Patch(const json& val) {
+            if (val.is_object()) {
+                if (val.contains("label") && val["label"].is_string()) {
+                    m_label = val["label"].template get<std::string>();
+                }
+                if (val.contains("min") && val["min"].is_number()) {
+                    m_min = val["min"].template get<float>();
+                }
+                if (val.contains("max") && val["max"].is_number()) {
+                    m_max = val["max"].template get<float>();
+                }
+            }
+        }
 };
 
 class MultiSlider final : public Widget {
@@ -425,7 +615,27 @@ class MultiSlider final : public Widget {
         int m_decimalDigits;
         std::string m_label;
 
-        static std::unique_ptr<MultiSlider> makeMultiSliderWidget(int id, std::string label, float min, float max, int numValues, int decimalDigits, const json& defaultValues) {
+        inline static std::unique_ptr<MultiSlider> makeWidget(const json& val) {
+            if (val.is_object()) {
+                auto id = val["id"].template get<int>();
+                auto numValues = val.contains("numValues") && val["numValues"].is_number() ? val["numValues"].template get<int>() : 2;
+                auto decimalDigits = val.contains("decimalDigits") && val["decimalDigits"].is_number() ? val["decimalDigits"].template get<int>() : 0;
+                
+                auto min = val.contains("min") && val["min"].is_number() ? val["min"].template get<float>() : 0.0f;
+                auto max = val.contains("max") && val["max"].is_number() ? val["max"].template get<float>() : 10.0f;
+                auto label = val.contains("label") && val["label"].is_string() ? val["label"].template get<std::string>() : "";
+                
+                if (val.contains("defaultValues") && val["defaultValues"].is_array() && val["defaultValues"].size() == numValues) {
+                    return MultiSlider::makeWidget(id, label, min, max, numValues, decimalDigits, val["defaultValues"]);
+                } else {
+                    return MultiSlider::makeWidget(id, label, min, max, numValues, decimalDigits);
+                }
+            }
+
+            throw std::invalid_argument("Invalid JSON data");
+        }
+
+        static std::unique_ptr<MultiSlider> makeWidget(int id, std::string label, float min, float max, int numValues, int decimalDigits, const json& defaultValues) {
             MultiSlider instance(id, label, min, max, numValues, decimalDigits);
 
             for (auto& [key, item] : defaultValues.items()) {
@@ -435,12 +645,29 @@ class MultiSlider final : public Widget {
             return std::make_unique<MultiSlider>(std::move(instance));
         }
 
-        static std::unique_ptr<MultiSlider> makeMultiSliderWidget(int id, std::string label, float min, float max, int numValues, int decimalDigits) {
+        static std::unique_ptr<MultiSlider> makeWidget(int id, std::string label, float min, float max, int numValues, int decimalDigits) {
             MultiSlider instance(id, label, min, max, numValues, decimalDigits);
 
             return std::make_unique<MultiSlider>(std::move(instance));
         }
 
         void Render(ReactImgui* view);
+
+        void Patch(const json& val) {
+            if (val.is_object()) {
+                if (val.contains("label") && val["label"].is_string()) {
+                    m_label = val["label"].template get<std::string>();
+                }
+                if (val.contains("min") && val["min"].is_number()) {
+                    m_min = val["min"].template get<float>();
+                }
+                if (val.contains("max") && val["max"].is_number()) {
+                    m_max = val["max"].template get<float>();
+                }
+                if (val.contains("decimalDigits") && val["decimalDigits"].is_number()) {
+                    m_decimalDigits = val["decimalDigits"].template get<int>();
+                }
+            }
+        }
 };
 

--- a/packages/dear-imgui/cpp/widget.h
+++ b/packages/dear-imgui/cpp/widget.h
@@ -35,6 +35,17 @@ class Widget {
 
         inline static OnTextChangedCallback onInputTextChange_;
 
+        template <typename T> 
+        static std::unique_ptr<T> makeWidget(const json& val) {
+            if (val.is_object()) {
+                auto id = val["id"].template get<int>();
+                
+                return std::make_unique<T>(id);
+            }
+
+            throw std::invalid_argument("Invalid JSON data");
+        }
+
         Widget(int id) {
             m_id = id;
             m_type = "Unknown";

--- a/packages/dear-imgui/cpp/widget.h
+++ b/packages/dear-imgui/cpp/widget.h
@@ -122,6 +122,17 @@ class SeparatorText final : public Widget {
     public:
         std::string m_label;
 
+        static std::unique_ptr<SeparatorText> makeWidget(const json& widgetDef) {
+            if (widgetDef.is_object()) {
+                auto id = widgetDef["id"].template get<int>();
+                std::string label = widgetDef["label"].template get<std::string>();
+
+                return std::make_unique<SeparatorText>(id, label);
+            }
+
+            throw std::invalid_argument("Invalid JSON data");
+        }
+
         SeparatorText(int id, std::string label) : Widget(id) {
             m_type = "SeparatorText";
             m_label = label;
@@ -141,6 +152,17 @@ class SeparatorText final : public Widget {
 class BulletText final : public Widget {
     public:
         std::string m_text;
+
+        static std::unique_ptr<BulletText> makeWidget(const json& widgetDef) {
+            if (widgetDef.is_object()) {
+                auto id = widgetDef["id"].template get<int>();
+                std::string text = widgetDef["text"].template get<std::string>();
+
+                return std::make_unique<BulletText>(id, text);
+            }
+
+            throw std::invalid_argument("Invalid JSON data");
+        }
 
         BulletText(int id, std::string text) : Widget(id) {
             m_type = "BulletText";
@@ -162,6 +184,17 @@ class UnformattedText final : public Widget {
     public:
         std::string m_text;
 
+        static std::unique_ptr<UnformattedText> makeWidget(const json& widgetDef) {
+            if (widgetDef.is_object()) {
+                auto id = widgetDef["id"].template get<int>();
+                std::string text = widgetDef["text"].template get<std::string>();
+
+                return std::make_unique<UnformattedText>(id, text);
+            }
+
+            throw std::invalid_argument("Invalid JSON data");
+        }
+
         UnformattedText(int id, std::string text) : Widget(id) {
             m_type = "UnformattedText";
             m_text = text;
@@ -181,6 +214,17 @@ class UnformattedText final : public Widget {
 class DisabledText final : public Widget {
     public:
         std::string m_text;
+
+        static std::unique_ptr<DisabledText> makeWidget(const json& widgetDef) {
+            if (widgetDef.is_object()) {
+                auto id = widgetDef["id"].template get<int>();
+                std::string text = widgetDef["text"].template get<std::string>();
+
+                return std::make_unique<DisabledText>(id, text);
+            }
+
+            throw std::invalid_argument("Invalid JSON data");
+        }
 
         DisabledText(int id, std::string text) : Widget(id) {
             m_type = "DisabledText";
@@ -214,6 +258,17 @@ class TabItem final : public Widget {
     public:
         std::string m_label;
 
+        static std::unique_ptr<TabItem> makeWidget(const json& widgetDef) {
+            if (widgetDef.is_object()) {
+                auto id = widgetDef["id"].template get<int>();
+                std::string label = widgetDef["label"].template get<std::string>();
+
+                return std::make_unique<TabItem>(id, label);
+            }
+
+            throw std::invalid_argument("Invalid JSON data");
+        }
+
         TabItem(int id, std::string label) : Widget(id) {
             m_type = "TabItem";
             m_handlesChildrenWithinRenderMethod = true;
@@ -235,6 +290,17 @@ class CollapsingHeader final : public Widget {
     public:
         std::string m_label;
 
+        static std::unique_ptr<CollapsingHeader> makeWidget(const json& widgetDef) {
+            if (widgetDef.is_object()) {
+                auto id = widgetDef["id"].template get<int>();
+                std::string label = widgetDef["label"].template get<std::string>();
+
+                return std::make_unique<CollapsingHeader>(id, label);
+            }
+
+            throw std::invalid_argument("Invalid JSON data");
+        }
+
         CollapsingHeader(int id, std::string label) : Widget(id) {
             m_type = "CollapsingHeader";
             m_handlesChildrenWithinRenderMethod = true;
@@ -255,6 +321,17 @@ class CollapsingHeader final : public Widget {
 class TextWrap final : public Widget {
     public:
         double m_width;
+
+        static std::unique_ptr<TextWrap> makeWidget(const json& widgetDef) {
+            if (widgetDef.is_object()) {
+                auto id = widgetDef["id"].template get<int>();
+                double width = widgetDef["width"].template get<double>();
+
+                return std::make_unique<TextWrap>(id, width);
+            }
+
+            throw std::invalid_argument("Invalid JSON data");
+        }
 
         TextWrap(int id, double width) : Widget(id) {
             m_type = "TextWrap";
@@ -288,6 +365,17 @@ class ItemTooltip final : public Widget {
 class TreeNode final : public Widget {
     public:
         std::string m_label;
+
+        static std::unique_ptr<TreeNode> makeWidget(const json& widgetDef) {
+            if (widgetDef.is_object()) {
+                auto id = widgetDef["id"].template get<int>();
+                std::string label = widgetDef["label"].template get<std::string>();
+
+                return std::make_unique<TreeNode>(id, label);
+            }
+
+            throw std::invalid_argument("Invalid JSON data");
+        }
 
         TreeNode(int id, std::string label) : Widget(id) {
             m_type = "TreeNode";

--- a/packages/dear-imgui/ts/src/lib/react-native/nativeFabricUiManager.js
+++ b/packages/dear-imgui/ts/src/lib/react-native/nativeFabricUiManager.js
@@ -12,7 +12,13 @@ export default class {
         this.wasmModule = wasmModule;
     }
     dispatchEvent = (rootNodeID, topLevelType, nativeEventParam) => {
-        this.dispatchEventFn(this.fiberNodesMap.get(rootNodeID), topLevelType, nativeEventParam);
+        setTimeout(() => {
+            this.dispatchEventFn(
+                this.fiberNodesMap.get(rootNodeID),
+                topLevelType,
+                nativeEventParam,
+            );
+        }, 0);
     };
     createNode = (generatedId, uiViewClassName, requiresClone, payload, fiberNode) => {
         // console.log("createNode", generatedId, uiViewClassName, requiresClone, payload, fiberNode);


### PR DESCRIPTION
The primary aim here is to reduce repetition.

There's still a chunky if-else-if block in `ReactImgui::InitWidget()`.

I need to find an elegant way to map widget types to static methods. I am thinking of using std::bind but I have a suspicion I can leverage templates.