### PR TITLE
Element internal ops are now queued in dedicated replay subjects

### DIFF
--- a/packages/dear-imgui/cpp/include/element/element.h
+++ b/packages/dear-imgui/cpp/include/element/element.h
@@ -37,6 +37,8 @@ class Element {
 
         virtual void Patch(const json& elementPatchDef, ReactImgui* view);
 
+        virtual bool HasInternalOps();
+
         virtual void HandleInternalOp(const json& opDef);
 
         virtual float GetLayoutLeftFromParentNode(YGNodeRef node, float left);

--- a/packages/dear-imgui/cpp/include/reactimgui.h
+++ b/packages/dear-imgui/cpp/include/reactimgui.h
@@ -23,7 +23,6 @@ enum ElementOp {
     OpPatchElement,
     OpSetChildren,
     OpAppendChild,
-    OpInternal,
 };
 
 struct ElementOpDef {
@@ -33,8 +32,7 @@ struct ElementOpDef {
 
 class ReactImgui : public ImPlotView {
     private:
-        int m_mapGeneratorJobCounter = 0;
-        std::unordered_map<int, std::unique_ptr<MapGenerator>> m_mapGeneratorJobs;
+        std::unordered_map<int, rpp::subjects::serialized_replay_subject<json>> m_elementInternalOpsSubject;
 
         rpp::subjects::serialized_replay_subject<ElementOpDef> m_elementOpSubject;
 
@@ -62,8 +60,6 @@ class ReactImgui : public ImPlotView {
         std::mutex m_hierarchy_mutex;
 
         std::unordered_map<int, std::unique_ptr<char[]>> m_floatFormatChars;
-
-        std::unordered_map<int, std::unique_ptr<Texture>> m_textures;
 
         ImGuiStyle m_baseStyle;
 
@@ -119,8 +115,6 @@ class ReactImgui : public ImPlotView {
         void QueueAppendChild(int parentId, int childId);
 
         void QueueElementInternalOp(int id, std::string& widgetOpDef);
-
-        void RenderMap(int id, double centerX, double centerY, int zoom);
 
         void AppendTextToClippedMultiLineTextRenderer(int id, const std::string& data);
 

--- a/packages/dear-imgui/cpp/include/widget/combo.h
+++ b/packages/dear-imgui/cpp/include/widget/combo.h
@@ -89,6 +89,8 @@ class Combo final : public StyledWidget {
 
         void Patch(const json& widgetPatchDef, ReactImgui* view) override;
 
+        bool HasInternalOps();
+
         void HandleInternalOp(const json& opDef);
 
         void Init() override {

--- a/packages/dear-imgui/cpp/include/widget/input_text.h
+++ b/packages/dear-imgui/cpp/include/widget/input_text.h
@@ -58,6 +58,8 @@ class InputText final : public StyledWidget {
 
         void Patch(const json& widgetPatchDef, ReactImgui* view) override;
 
+        bool HasInternalOps();
+
         void HandleInternalOp(const json& opDef);
 
         void SetValue(std::string& value) {

--- a/packages/dear-imgui/cpp/include/widget/map_view.h
+++ b/packages/dear-imgui/cpp/include/widget/map_view.h
@@ -1,8 +1,14 @@
+#include "mapgenerator.h"
 #include "styled_widget.h"
 
 class MapView final : public StyledWidget {
 private:
     ImVec2 m_offset;
+
+    int m_mapGeneratorJobCounter = 0;
+    std::unordered_map<int, std::unique_ptr<MapGenerator>> m_mapGeneratorJobs;
+
+    std::unordered_map<int, std::unique_ptr<Texture>> m_textures;
 
 public:
     static std::unique_ptr<MapView> makeWidget(const json& widgetDef, std::optional<BaseStyle> maybeStyle, ReactImgui* view) {
@@ -26,4 +32,8 @@ public:
     }
 
     void Render(ReactImgui* view) override;
+
+    bool HasInternalOps();
+
+    void HandleInternalOp(const json& opDef);
 };

--- a/packages/dear-imgui/cpp/include/widget/table.h
+++ b/packages/dear-imgui/cpp/include/widget/table.h
@@ -70,6 +70,8 @@ class Table final : public StyledWidget {
 
         void Patch(const json& widgetPatchDef, ReactImgui* view) override;
 
+        bool HasInternalOps();
+
         void HandleInternalOp(const json& opDef);
 
         void SetColumns(const json& columnsDef) {

--- a/packages/dear-imgui/cpp/src/element/element.cpp
+++ b/packages/dear-imgui/cpp/src/element/element.cpp
@@ -109,4 +109,8 @@ void Element::Patch(const json& nodeDef, ReactImgui* view) {
     }
 };
 
+bool Element::HasInternalOps() {
+    return false;
+};
+
 void Element::HandleInternalOp(const json& opDef) {};

--- a/packages/dear-imgui/cpp/src/main.cpp
+++ b/packages/dear-imgui/cpp/src/main.cpp
@@ -194,10 +194,6 @@ class WasmRunner {
             return m_view->GetAvailableFonts().dump();
         }
 
-        void renderMap(int id, double centerX, double centerY, int zoom) {
-            m_view->RenderMap(id, centerX, centerY, zoom);
-        }
-
         void appendTextToClippedMultiLineTextRenderer(int id, std::string& data) {
             m_view->AppendTextToClippedMultiLineTextRenderer(id, data);
         }
@@ -321,10 +317,6 @@ std::string getChildren(int id) {
     return IntVectorToJson(pRunner->getChildren(id)).dump();
 }
 
-void renderMap(int id, double centerX, double centerY, int zoom) {
-    pRunner->renderMap(id, centerX, centerY, zoom);
-}
-
 void appendTextToClippedMultiLineTextRenderer(int id, std::string data) {
     pRunner->appendTextToClippedMultiLineTextRenderer(id, data);
 }
@@ -346,7 +338,6 @@ EMSCRIPTEN_BINDINGS(my_module) {
     emscripten::function("setChildren", &setChildren);
     emscripten::function("appendChild", &appendChild);
     emscripten::function("getChildren", &getChildren);
-    emscripten::function("renderMap", &renderMap);
     emscripten::function("appendTextToClippedMultiLineTextRenderer", &appendTextToClippedMultiLineTextRenderer);
     emscripten::function("getStyle", &getStyle);
     emscripten::function("patchStyle", &patchStyle);

--- a/packages/dear-imgui/cpp/src/reactimgui.cpp
+++ b/packages/dear-imgui/cpp/src/reactimgui.cpp
@@ -460,7 +460,7 @@ void ReactImgui::QueueCreateElement(std::string& elementJsonAsString) {
         ElementOpDef elementOp{OpCreateElement,json::parse(elementJsonAsString)};
         m_elementOpSubject.get_observer().on_next(elementOp);
     } catch (nlohmann::detail::parse_error& parseError) {
-        printf("ReactImgui::SetElement, parse error: %s\n", parseError.what());
+        printf("ReactImgui::QueueCreateElement, parse error: %s\n", parseError.what());
     }
 };
 
@@ -471,7 +471,7 @@ void ReactImgui::QueuePatchElement(const int id, std::string& elementJsonAsStrin
         ElementOpDef elementOp{OpPatchElement,opDef};
         m_elementOpSubject.get_observer().on_next(elementOp);
     } catch (nlohmann::detail::parse_error& parseError) {
-        printf("ReactImgui::SetElement, parse error: %s\n", parseError.what());
+        printf("ReactImgui::QueuePatchElement, parse error: %s\n", parseError.what());
     }
 };
 
@@ -483,7 +483,7 @@ void ReactImgui::QueueAppendChild(int parentId, int childId) {
         ElementOpDef elementOp{OpAppendChild,opDef};
         m_elementOpSubject.get_observer().on_next(elementOp);
     } catch (nlohmann::detail::parse_error& parseError) {
-        printf("ReactImgui::SetElement, parse error: %s\n", parseError.what());
+        printf("ReactImgui::QueueAppendChild, parse error: %s\n", parseError.what());
     }
 };
 
@@ -495,7 +495,7 @@ void ReactImgui::QueueSetChildren(const int parentId, const std::vector<int>& ch
         ElementOpDef elementOp{OpSetChildren,opDef};
         m_elementOpSubject.get_observer().on_next(elementOp);
     } catch (nlohmann::detail::parse_error& parseError) {
-        printf("ReactImgui::SetElement, parse error: %s\n", parseError.what());
+        printf("ReactImgui::QueueSetChildren, parse error: %s\n", parseError.what());
     }
 };
 
@@ -507,7 +507,7 @@ void ReactImgui::QueueElementInternalOp(const int id, std::string& widgetOpDef) 
             m_elementInternalOpsSubject[id].get_observer().on_next(opDef);
         }
     } catch (nlohmann::detail::parse_error& parseError) {
-        printf("ReactImgui::SetElement, parse error: %s\n", parseError.what());
+        printf("ReactImgui::QueueElementInternalOp, parse error: %s\n", parseError.what());
     }
 };
 

--- a/packages/dear-imgui/cpp/src/widget/combo.cpp
+++ b/packages/dear-imgui/cpp/src/widget/combo.cpp
@@ -44,6 +44,10 @@ void Combo::Patch(const json& widgetPatchDef, ReactImgui* view) {
     }
 };
 
+bool Combo::HasInternalOps() {
+    return true;
+}
+
 void Combo::HandleInternalOp(const json& opDef) {
     if (opDef.contains("op") && opDef["op"].is_string()) {
         auto op = opDef["op"].template get<std::string>();

--- a/packages/dear-imgui/cpp/src/widget/input_text.cpp
+++ b/packages/dear-imgui/cpp/src/widget/input_text.cpp
@@ -21,6 +21,10 @@ void InputText::Patch(const json& widgetPatchDef, ReactImgui* view) {
     }
 };
 
+bool InputText::HasInternalOps() {
+    return true;
+}
+
 void InputText::HandleInternalOp(const json& opDef) {
     if (opDef.contains("op") && opDef["op"].is_string()) {
         auto op = opDef["op"].template get<std::string>();

--- a/packages/dear-imgui/cpp/src/widget/map_view.cpp
+++ b/packages/dear-imgui/cpp/src/widget/map_view.cpp
@@ -1,6 +1,7 @@
 #include <imgui.h>
 #include <yoga/YGNodeLayout.h>
 
+#include "mapgenerator.h"
 #include "widget/map_view.h"
 #include "reactimgui.h"
 
@@ -13,7 +14,7 @@ bool MapView::HasCustomHeight() {
 }
 
 void MapView::Render(ReactImgui* view) {
-    if (view->m_textures.contains(0)) {
+    if (m_textures.contains(0)) {
 
         auto imageSize = ImVec2(YGNodeLayoutGetWidth(m_layoutNode->m_node), YGNodeLayoutGetHeight(m_layoutNode->m_node));
 
@@ -25,8 +26,8 @@ void MapView::Render(ReactImgui* view) {
 
             ImDrawList* drawList = ImGui::GetWindowDrawList();
 
-            double boxWidthPct = imageSize.x / view->m_textures[0]->width;
-            double boxHeightPct = imageSize.y / view->m_textures[0]->height;
+            double boxWidthPct = imageSize.x / m_textures[0]->width;
+            double boxHeightPct = imageSize.y / m_textures[0]->height;
 
             ImGui::InvisibleButton("##map_canvas", imageSize);
             if (ImGui::IsItemActive() && ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
@@ -41,12 +42,12 @@ void MapView::Render(ReactImgui* view) {
                     m_offset.y = 0;
                 }
 
-                if (m_offset.x > (view->m_textures[0]->width - imageSize.x)) {
-                    m_offset.x = view->m_textures[0]->width - imageSize.x;
+                if (m_offset.x > (m_textures[0]->width - imageSize.x)) {
+                    m_offset.x = m_textures[0]->width - imageSize.x;
                 }
 
-                if (m_offset.y > (view->m_textures[0]->height - imageSize.y)) {
-                    m_offset.y = view->m_textures[0]->height - imageSize.y;
+                if (m_offset.y > (m_textures[0]->height - imageSize.y)) {
+                    m_offset.y = m_textures[0]->height - imageSize.y;
                 }
             }
 
@@ -58,13 +59,12 @@ void MapView::Render(ReactImgui* view) {
                 return;
             }
 
-
             ImGui::PushClipRect(p0, p1, true);
 
-            ImVec2 uvMin = ImVec2(m_offset.x / view->m_textures[0]->width, m_offset.y / view->m_textures[0]->height);
-            ImVec2 uvMax = ImVec2((m_offset.x / view->m_textures[0]->width) + boxWidthPct, (m_offset.y / view->m_textures[0]->height) + boxHeightPct);
+            ImVec2 uvMin = ImVec2(m_offset.x / m_textures[0]->width, m_offset.y / m_textures[0]->height);
+            ImVec2 uvMax = ImVec2((m_offset.x / m_textures[0]->width) + boxWidthPct, (m_offset.y / m_textures[0]->height) + boxHeightPct);
 
-            drawList->AddImage((void*)view->m_textures[0]->textureView, p0, p1, uvMin, uvMax);
+            drawList->AddImage((void*)m_textures[0]->textureView, p0, p1, uvMin, uvMax);
             ImGui::PopClipRect();
 
             ImGui::EndGroup();
@@ -73,3 +73,45 @@ void MapView::Render(ReactImgui* view) {
     }
 };
 
+bool MapView::HasInternalOps() {
+    return true;
+}
+
+// void ReactImgui::RenderMap(int id, double centerX, double centerY, int zoom)
+void MapView::HandleInternalOp(const json& opDef) {
+    if (opDef.contains("op") && opDef["op"].is_string()) {
+        auto op = opDef["op"].template get<std::string>();
+
+        if (op == "render"
+            && opDef.contains("centerX") && opDef["centerX"].is_number()
+            && opDef.contains("centerY") && opDef["centerY"].is_number()
+            && opDef.contains("zoom") && opDef["zoom"].is_number()) {
+
+            auto centerX = opDef["centerX"].template get<double>();
+            auto centerY = opDef["centerY"].template get<double>();
+            auto zoom = opDef["zoom"].template get<int>();
+
+            MapGeneratorOptions options;
+            options.m_width = 600;
+            options.m_height = 600;
+
+            m_mapGeneratorJobCounter++;
+
+            m_mapGeneratorJobs[m_mapGeneratorJobCounter] = std::make_unique<MapGenerator>(options, [this] (const void* data, const size_t numBytes) {
+                Texture texture{};
+
+                const bool ret = LoadTexture(m_view->GetDevice(), data, static_cast<int>(numBytes), &texture);
+                IM_ASSERT(ret);
+
+                // TODO: add proper texture management
+                m_textures[0] = std::make_unique<Texture>(texture);
+
+                printf("Loaded texture, width: %d, height: %d\n", m_textures[0]->width, m_textures[0]->height);
+
+                // TODO: remove job from map
+            });
+
+            m_mapGeneratorJobs[m_mapGeneratorJobCounter]->Render(std::make_tuple(centerX, centerY), zoom);
+        }
+    }
+};

--- a/packages/dear-imgui/cpp/src/widget/table.cpp
+++ b/packages/dear-imgui/cpp/src/widget/table.cpp
@@ -88,6 +88,10 @@ void Table::Patch(const json& widgetPatchDef, ReactImgui* view) {
     }
 };
 
+bool Table::HasInternalOps() {
+    return true;
+}
+
 void Table::HandleInternalOp(const json& opDef) {
     if (opDef.contains("op") && opDef["op"].is_string()) {
         auto op = opDef["op"].template get<std::string>();

--- a/packages/dear-imgui/ts/src/lib/widgetRegistrationService.ts
+++ b/packages/dear-imgui/ts/src/lib/widgetRegistrationService.ts
@@ -76,7 +76,10 @@ export class WidgetRegistrationService {
         const fabricWidgetId = this.fabricWidgetsMapping.get(id);
         if (fabricWidgetId !== undefined) {
             try {
-                this.wasmModule.renderMap(fabricWidgetId, centerX, centerY, zoom);
+                this.wasmModule.elementInternalOp(
+                    fabricWidgetId,
+                    JSON.stringify({ op: "render", centerX, centerY, zoom }),
+                );
             } catch (error) {
                 // todo: propagate this?
                 console.error(error);


### PR DESCRIPTION
Moved map rendering logic to map view CPP file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new `HasInternalOps()` methods across various classes, enhancing control over internal operations.
	- Added new member variables to improve management of rendering tasks within the `MapView` class.

- **Refactor**
	- Enhanced internal operation handling in `ReactImgui`, shifting to a more reactive architecture.
	- Refactored `Render` method in the `MapView` class for better encapsulation and streamlined texture management.
	- Removed the `renderMap` function across different contexts to streamline rendering logic, preventing potential errors.

- **Documentation**
	- Updated internal comments to reflect changes and suggest potential future enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->